### PR TITLE
fix: Nested prosemirror object attributes Safari bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prosemirror-compress",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "ProseMirror compression",
   "main": "dist/index.js",
   "scripts": {

--- a/src/functions.js
+++ b/src/functions.js
@@ -31,7 +31,7 @@ function mapKeys(keysMap, obj) {
     Array.isArray(obj) ?
       obj.map(mapKeys.bind(0, keysMap))
     :
-      Object.assign({}, ...Object.entries(obj).map(
+      Object.assign({}, ...Object.entries({...obj}).map(
         function ([ key, value ]) {
           const [ mappedKey = key, valueKeysMap ] = keysMap[key] || []
           return ({ // '(' because of https://gitlab.com/Rich-Harris/buble/issues/182


### PR DESCRIPTION
This is a simple fix for a pretty hairy bug that took me a while to track down. Hope you'll bear with me while I explain:

When defining Prosemirror schemas, it is possible to set a node attribute whose value will be an array or object. For example: 
```
attrs: {
    items: { default: [] }
}
```
Prosemirror seems to create these attribute object values as prototype-less objects, i.e. `Object.create(null, { a: 1 })`. Because of this, when [calling Object.entries](https://github.com/xylk/prosemirror-compress/blob/master/src/functions.js#L34) on one of these prototype-less objects on in Safari which is using a polyfill to enable Object.entries support - Object.entries fails because `e.propertyIsEnumerable` is undefined, given that `propertyIsEnumerable` is an Object.prototype function. The error only happens in Safari. Perhaps Safari is stricter with their Object prototype handling?

This fix simply ensures all objects are assigned as prototyped objects before calling Object.entries.